### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:20.17-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Fix build error:

 > [ 6/16] RUN npm install -g npm@latest:
1.272 npm error code EBADENGINE
1.272 npm error engine Unsupported engine
1.272 npm error engine Not compatible with your version of node/npm: npm@11.2.0
1.272 npm error notsup Not compatible with your version of node/npm: npm@11.2.0
1.272 npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
1.272 npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
1.273 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-04-06T16_45_40_423Z-debug-0.log